### PR TITLE
Disable debugger statments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,79 @@
 node_modules
+
+# Ignore .DS_store file
+.DS_Store
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+
+### SublimeText ###
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+
+# User specific stuff
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -9,6 +9,10 @@ module.exports = {
 	},
 
 	rules: {
+		// Disallow debugger;
+		//http://eslint.org/docs/rules/no-debugger
+		'no-debugger': 'error',
+
 		// Disallow bitwise operators
 		// http://eslint.org/docs/rules/no-bitwise
 		'no-bitwise': 'error',


### PR DESCRIPTION
We don't want these guys getting through to production code as they can potentially stop a sites operation.

`debugger;`

I suggest we disable them by default in our lint config. We can still use them during development if we need to however this will now cause a build or lint to fail.. which i think is what we want.