### PR TITLE
Enforce dangling commas

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -126,8 +126,7 @@ module.exports = {
 
 		// Require or disallow trailing commas
 		// http://eslint.org/docs/rules/comma-dangle
-		// TODO: Talk to Damo and Keegan about turning this on
-		'comma-dangle': ['error', 'never'],
+		'comma-dangle': ['error', 'always-multiline'],
 
 		// Disallow Yoda Conditions
 		// http://eslint.org/docs/rules/yoda


### PR DESCRIPTION
I'm kind of expecting a healthy debate over this one.

But I would like to propose we enforce dangling comma's in our lint/style guide for multiline statements.

https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8

What do you all think?