### PR TITLE
Removed peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
     "eslint": "^3.8.1",
     "eslint-plugin-import": "^2.0.1"
   },
-  "peerDependencies": {
-    "eslint": "^3.8.1",
-    "eslint-plugin-import": "^2.0.1"
-  },
   "engines": {
     "node": ">= 4"
   },


### PR DESCRIPTION
Sometimes a project will want to use the ESLint configuration but not include the ESLint module itself. Currently the following warnings are displayed on install:

![image](https://user-images.githubusercontent.com/513363/27359457-2cd53b92-565f-11e7-87d5-baa1ef332dd0.png)

Example scenarios where this happens:

- The project doesn't have build scripts, and the config is purely used to configure the IDE.
- The build scripts live externally to the project, for example the project is just a small module living in a big project and the big project builds the small module.