### PR TITLE
Updated docs with babel parser instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ These packages provides Deloitte Digital's code standards as an ESLint extensibl
 - [Installation for ES6 + React projects](#installation-for-es6--react-projects)
 - [Installation for ES5 projects](#installation-for-es5-projects)
 
-> Please note: If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
+> Please note: If you are using Types such as Flow or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
 
 ## Installation for ES6 projects
 
@@ -83,7 +83,7 @@ module.exports = {
 
 ## Babel Parser Installation
 
-If you are using Types such as [Flow](https://github.com/facebook/flow) or or experimental features not supported in ESLint itself yet such as decorators.
+If you are using Types such as [Flow](https://github.com/facebook/flow) or experimental features not supported in ESLint itself yet such as decorators.
 
 Add `"parser": "babel-eslint"` to your `.eslintrc.js` file. Then `npm install babel-eslint --save-dev`
 

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,8 @@ These packages provides Deloitte Digital's code standards as an ESLint extensibl
 - [Installation for ES6 + React projects](#installation-for-es6--react-projects)
 - [Installation for ES5 projects](#installation-for-es5-projects)
 
+> NOTE: If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
+
 ## Installation for ES6 projects
 
 ```bash
@@ -79,6 +81,11 @@ module.exports = {
 };
 ```
 
+## Babel Parser Installation
+
+If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators.
+
+Add `"parser": "babel-eslint"` to your `.eslintrc.js` file. Then `npm install babel-eslint --save-dev`
 
 ## Who is Deloitte Digital?
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ These packages provides Deloitte Digital's code standards as an ESLint extensibl
 - [Installation for ES6 + React projects](#installation-for-es6--react-projects)
 - [Installation for ES5 projects](#installation-for-es5-projects)
 
-> NOTE: If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
+> ℹ️ If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
 
 ## Installation for ES6 projects
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ These packages provides Deloitte Digital's code standards as an ESLint extensibl
 - [Installation for ES6 + React projects](#installation-for-es6--react-projects)
 - [Installation for ES5 projects](#installation-for-es5-projects)
 
-> ℹ️ If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
+> Please note: If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators. Please additionally [configure the babel-parser](#babel-parser-installation).
 
 ## Installation for ES6 projects
 
@@ -83,9 +83,11 @@ module.exports = {
 
 ## Babel Parser Installation
 
-If you are using Types such as Flow or or experimental features not supported in ESLint itself yet such as decorators.
+If you are using Types such as [Flow](https://github.com/facebook/flow) or or experimental features not supported in ESLint itself yet such as decorators.
 
 Add `"parser": "babel-eslint"` to your `.eslintrc.js` file. Then `npm install babel-eslint --save-dev`
+
+Read more about configuring this package [here](https://github.com/babel/babel-eslint).
 
 ## Who is Deloitte Digital?
 


### PR DESCRIPTION
Given all the mobx work we are doing in Sydney and the popularity of tools like flow and mobx. I thought its worth documenting how to enable these features in the linter.

This is a no deployment required PR, docs only.