### PR TITLE
Fixed duplicate rule

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## ESLint Config Deloitte Changelog
 
+### [3.1.1]
+
+- Fixed duplicate of `jsx-a11y/label-has-for` rule
+
 ### [3.1.0]
 
 - Added npm lock files

--- a/packages/eslint-config-deloitte-react/package.json
+++ b/packages/eslint-config-deloitte-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-deloitte-react",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "This package provides Deloitte Digital's code standards as an ESLint extensible config",
   "main": "./index.js",
   "scripts": {

--- a/packages/eslint-config-deloitte-react/rules/jsx-a11y.js
+++ b/packages/eslint-config-deloitte-react/rules/jsx-a11y.js
@@ -67,10 +67,6 @@ module.exports = {
 		// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md
 		'jsx-a11y/interactive-supports-focus': 'off',
 
-		// Enforce that <label> elements have the htmlFor prop
-		// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-		'jsx-a11y/label-has-for': 'error',
-
 		// Enforce lang attribute has a valid value
 		// https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/lang.md
 		'jsx-a11y/lang': 'error',


### PR DESCRIPTION
Just removing a duplicate rule that causes eslint error

```
Configuration for rule "jsx-a11y/label-has-for" is invalid:
Value "[object Object]" no (or more than one) schemas match.
```