### PR TITLE
Webpack, linters and Karma run in Node

### DIFF
--- a/packages/eslint-config-deloitte/index.js
+++ b/packages/eslint-config-deloitte/index.js
@@ -11,4 +11,17 @@ module.exports = {
 			experimentalObjectRestSpread: true,
 		},
 	},
+	overrides: [
+		{
+			files: [
+				'.eslintrc.js',
+				'.stylelintrc.js',
+				'karma.conf.js',
+				'webpack.config.js',
+			],
+			env: {
+				node: true,
+			},
+		},
+	],
 };


### PR DESCRIPTION
So their files should be linted for the Node environment.