### PR TITLE
Enforce `async () => {}` instead of `async() => {}`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### [UNPUBLISHED]
 
+- Enforce `async () => {}` instead of `async() => {}`.
+
 ### [3.4.0]
 
 - Packages are now scoped to `@deloitte-digital-au`

--- a/packages/eslint-config/rules/best-practices.js
+++ b/packages/eslint-config/rules/best-practices.js
@@ -88,7 +88,14 @@ module.exports = {
 
 		// Enforce consistent spacing before opening parenthesis in function definitions
 		// http://eslint.org/docs/rules/space-before-function-parentheses
-		'space-before-function-paren': ['error', 'never'],
+		'space-before-function-paren': [
+			'error',
+			{
+				anonymous: 'never',
+				named: 'never',
+				asyncArrow: 'always',
+			},
+		],
 
 		// Disallow or enforce spaces inside of brackets
 		// http://eslint.org/docs/rules/array-bracket-spacing


### PR DESCRIPTION
It looks better and is consistent with prettier.